### PR TITLE
Makes the Camera follow the Player, and Change to a Capsule Hitbox

### DIFF
--- a/StageOne.tscn
+++ b/StageOne.tscn
@@ -1,9 +1,15 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://sprites/tile.png" type="Texture" id=2]
 
-[sub_resource type="RectangleShape2D" id=1]
+[sub_resource type="CapsuleShape2D" id=1]
+
+custom_solver_bias = 0.0
+radius = 3.188
+height = 9.9836
+
+[sub_resource type="RectangleShape2D" id=2]
 
 custom_solver_bias = 0.0
 extents = Vector2( 11, 11 )
@@ -13,6 +19,36 @@ extents = Vector2( 11, 11 )
 [node name="Player" parent="." index="0" instance=ExtResource( 1 )]
 
 position = Vector2( 126.812, 54.9918 )
+_sections_unfolded = [ "Collision", "Material", "Pause", "Pickable", "Transform", "Visibility", "Z Index", "collision" ]
+
+[node name="CollisionShape2D2" type="CollisionShape2D" parent="Player" index="2"]
+
+shape = SubResource( 1 )
+
+[node name="Camera2D" type="Camera2D" parent="Player" index="3"]
+
+anchor_mode = 1
+rotating = false
+current = true
+zoom = Vector2( 1, 1 )
+limit_left = -10000000
+limit_top = -10000000
+limit_right = 10000000
+limit_bottom = 10000000
+limit_smoothed = false
+drag_margin_h_enabled = true
+drag_margin_v_enabled = true
+smoothing_enabled = false
+smoothing_speed = 5.0
+offset_v = 0.0
+offset_h = 0.0
+drag_margin_left = 0.2
+drag_margin_top = 0.2
+drag_margin_right = 0.2
+drag_margin_bottom = 0.2
+editor_draw_screen = true
+editor_draw_limits = false
+editor_draw_drag_margin = false
 
 [node name="Ground0" type="Sprite" parent="." index="1"]
 
@@ -34,7 +70,7 @@ bounce = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Ground0/StaticBody2D" index="0"]
 
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 
 [node name="Ground1" type="Sprite" parent="." index="2"]
 
@@ -56,7 +92,7 @@ bounce = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Ground1/StaticBody2D" index="0"]
 
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 
 [node name="Ground2" type="Sprite" parent="." index="3"]
 
@@ -78,7 +114,7 @@ bounce = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Ground2/StaticBody2D" index="0"]
 
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 
 [node name="Ground3" type="Sprite" parent="." index="4"]
 
@@ -100,7 +136,7 @@ bounce = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Ground3/StaticBody2D" index="0"]
 
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 
 [node name="Ground4" type="Sprite" parent="." index="5"]
 
@@ -122,7 +158,7 @@ bounce = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Ground4/StaticBody2D" index="0"]
 
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 
 [node name="Ground5" type="Sprite" parent="." index="6"]
 
@@ -144,6 +180,6 @@ bounce = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Ground5/StaticBody2D" index="0"]
 
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 
 


### PR DESCRIPTION
Adds a `Camera2D` child node to the `Player` node that allows the camera to follow it, and changes the hitbox.